### PR TITLE
Adds support for arbitrary suffixes

### DIFF
--- a/pydra/tasks/dcm2niix/utils.py
+++ b/pydra/tasks/dcm2niix/utils.py
@@ -22,11 +22,12 @@ def dcm2niix_out_file(out_dir, filename, echo, suffix, compress):
 
     # Check to see if multiple echos exist in the DICOM dataset
     if not out_file.exists():
-        if echoes := [
+        echoes = [
             str(p)
             for p in out_file.parent.iterdir()
             if p.stem.startswith(filename + "_e")
-        ]:
+        ]
+        if echoes:
             raise ValueError(
                 "DICOM dataset contains multiple echos, please specify which "
                 "echo you want via the 'echo' input:\n"


### PR DESCRIPTION
This PR adds the `suffix` input field, which enables the user to select one set of disambiguated files that are generated by dcm2niix to be returned by the interface (see https://github.com/rordenlab/dcm2niix/blob/master/FILENAMING.md#file-name-post-fixes-image-disambiguation).

I'm not sure if this breaks convention for how these kinds of switches are handled a little bit, in that only one set of the generated outputs are returned. Alternatively, we could create output fields for all possible combinations, i.e. out_file_imaginary, out_file_real, out_file_phase, out_file_phMag, etc... The reason I didn't go for this approach is that it is
impossible to take this approach for multi-echo sequences, which could have arbitrary amounts of different suffixes, i.e. _e1 ..., _eN so I have already implemented a "switch" type logic between which output is returned.

This means that if a user wants to use multiple output files (i.e. with different suffixes), they will need to rerun the Dcm2Niix multiple times, selecting the appropriate output file each run. Maybe not ideal, but could actually be easier to build into pipelines I reckon. Interested to get your thoughts.