### PR TITLE
[WIP] Adds "out_files" output field to handle disambiguated postfixes

### DIFF
--- a/pydra/tasks/dcm2niix/utils.py
+++ b/pydra/tasks/dcm2niix/utils.py
@@ -1,5 +1,4 @@
 import attrs
-import typing as ty
 from pathlib import Path
 from pydra import ShellCommandTask
 from pydra.engine.specs import ShellSpec, ShellOutSpec, File, Directory, SpecInfo

--- a/pydra/tasks/dcm2niix/utils.py
+++ b/pydra/tasks/dcm2niix/utils.py
@@ -5,22 +5,22 @@ from pydra import ShellCommandTask
 from pydra.engine.specs import ShellSpec, ShellOutSpec, File, Directory, SpecInfo
 
 
-def out_file_path(out_dir, filename, suffix, ext):
+def out_file_path(out_dir, filename, file_suffix, ext):
     """Attempting to handle the different suffixes that are appended to filenames
     created by Dcm2niix (see https://github.com/rordenlab/dcm2niix/blob/master/FILENAMING.md)
     """
 
     fpath = Path(out_dir) / filename
-    fpath = fpath.with_suffix((suffix if suffix else "") + ext).absolute()
+    fpath = fpath.with_suffix((file_suffix if file_suffix else "") + ext).absolute()
 
     # Check to see if multiple echos exist in the DICOM dataset
     if not fpath.exists():
-        if suffix is not None:  # NB: doesn't match attrs.NOTHING
+        if file_suffix is not None:  # NB: doesn't match attrs.NOTHING
             neighbours = [
                 str(p) for p in fpath.parent.iterdir() if p.name.endswith(ext)
             ]
             raise ValueError(
-                f"\nDid not find expected file '{fpath}' (suffix={suffix}) "
+                f"\nDid not find expected file '{fpath}' (file_suffix={file_suffix}) "
                 "after DICOM -> NIfTI conversion, please see "
                 "https://github.com/rordenlab/dcm2niix/blob/master/FILENAMING.md for the "
                 "list of suffixes that dcm2niix produces and provide an appropriate "
@@ -88,7 +88,7 @@ input_fields = [
         {"argstr": "-f '{filename}'", "help_string": "The output name for the file"},
     ),
     (
-        "suffix",
+        "file_suffix",
         str,
         {
             "help_string": (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools==62", "wheel"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,3 +66,17 @@ parentdir_prefix =
 [tool:pytest]
 addopts          = --doctest-modules --doctest-report ndiff
 doctest_optionflags= NORMALIZE_WHITESPACE ELLIPSIS
+
+[flake8]
+doctests = True
+exclude =
+    **/__init__.py
+    *build/
+    pydra/tasks/dcm2niix/_version.py
+    versioneer.py
+    docs/source/conf.py
+max-line-length = 88
+select = C,E,F,W,B,B950
+extend-ignore = E203,E501
+per-file-ignores =
+    setup.py:F401

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,3 +62,7 @@ versionfile_source = pydra/tasks/dcm2niix/_version.py
 versionfile_build = pydra/tasks/dcm2niix/_version.py
 tag_prefix =
 parentdir_prefix =
+
+[tool:pytest]
+addopts          = --doctest-modules --doctest-report ndiff
+doctest_optionflags= NORMALIZE_WHITESPACE ELLIPSIS

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[DEFAULT]
-subpackage = dcm2niix
-
 [metadata]
 author = Thomas G. Close
 author_email = tom.g.close@gmail.com
@@ -28,8 +25,8 @@ packages = find_namespace:
 
 [options.packages.find]
 include =
-    pydra.tasks.%(subpackage)s
-    pydra.tasks.%(subpackage)s.*
+    pydra.tasks.dcm2niix
+    pydra.tasks.dcm2niix.*
 
 [options.extras_require]
 doc =
@@ -61,7 +58,7 @@ all =
 [versioneer]
 VCS = git
 style = pep440
-versionfile_source = pydra/tasks/%(subpackage)s/_version.py
-versionfile_build = pydra/tasks/%(subpackage)s/_version.py
+versionfile_source = pydra/tasks/dcm2niix/_version.py
+versionfile_build = pydra/tasks/dcm2niix/_version.py
 tag_prefix =
 parentdir_prefix =


### PR DESCRIPTION
With the exception of fMRI and DWI datasets, if dcm2niix processes a file with more than 3 dimensions (e.g. multiple echos, multiple antennas/coils, multiple real/imaginary/mag/phase components, etc...), it will split the image into separate images disambiguated by postfixes. This PR adds a new catchall `out_files` output field that collects all these images into a single list. It also adds replaces the `echo` and `suffix` input fields with a single `file_postfix` field, that selects which of the disambiguated files to return in the singular `out_file` field (returning attrs.NOTHING if `file_postfix is None`)